### PR TITLE
Fix memory corruption while parsing functions

### DIFF
--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -759,7 +759,7 @@ static Shnode_t *funct(Lex_t *lexp)
 	register Shnode_t *t;
 	register int flag;
 	struct slnod *volatile slp=0;
-	Stak_t *volatile savstak;
+	Stak_t *volatile savstak=0;
 	Sfoff_t	first, last;
 	struct functnod *volatile fp;
 	Sfio_t *iop;


### PR DESCRIPTION
Always initialize savstak variable to NULL to avoid any undefined behavior
Related: rhbz#1451057